### PR TITLE
bFilter=false causes trim reference error

### DIFF
--- a/lib/searchBuilder.js
+++ b/lib/searchBuilder.js
@@ -87,7 +87,7 @@ function loadWords(searchStr, words, isRegexp) {
 }
 
 function getSearchValue() {
-  return query[QUERY_SEARCH];
+  return query[QUERY_SEARCH] || "";
 }
 
 function isSearchRegexp() {


### PR DESCRIPTION
In the client app, turning off the dataTables search via setting bFilter to false causes 500 from server: "TypeError: Cannot call method 'trim' of undefined". This fixes it.
