### PR TITLE
Don't throw Error if select is empty

### DIFF
--- a/lib/dataTable.js
+++ b/lib/dataTable.js
@@ -65,7 +65,6 @@ function dataTable(query, options, callback) {
   if ('function' != typeof callback) { throw new Error("Missing callback !"); }
   if ('object'!= typeof query) { return callback(new Error("Invalid query !")); }
   var searchCriteria = buildSearchCriteria(self, query, options);
-  if (searchCriteria.isSelectEmpty()) { return callback(new Error("No valid field requested !")); }
   Tools.debug("Search Criteria builded:", searchCriteria.toString());
   var resultHolder = buildResultHolder(query);
   countAllRecords.call(self, searchCriteria, resultHolder,


### PR DESCRIPTION
searchCritera.select is automatically empty after its creation, so the error will always be thrown in this case and the request will never work.