### PR TITLE
Move MongoDB project before MongoDB sort

### DIFF
--- a/lib/dataTable.js
+++ b/lib/dataTable.js
@@ -133,18 +133,9 @@ function countFilteredRecords(searchCriteria, resultHolder, callback) {
 function fetchData(searchCriteria, resultHolder, callback) {
   var query = this.aggregate();
   if (searchCriteria.conditions) query.match(searchCriteria.conditions);
-  // Sort before skip and limit in order to preserve initial sort integrity
-  if (Object.keys(searchCriteria.sort).length > 0) {
-    query.sort(searchCriteria.sort);
-  }
-  query.skip(searchCriteria.pageStart);
-  if (searchCriteria.pageSize >= 0) query.limit(searchCriteria.pageSize);
-  if (searchCriteria.aggregates.length > 0) {
-    searchCriteria.aggregates.forEach(function(aggregate) {
-      query.unwind(aggregate.unwind).match(aggregate.match)
-        .group(aggregate.group).project(aggregate.project);
-    });
-  }
+
+  // Project before sort to temporarily relove issues in mongoDB which uses non optimal index of query because of sort
+  // bit.ly/MongoDBSortBug
   var project = {};
   for (var key in searchCriteria.select) {
     project[key] = searchCriteria.select[key];
@@ -167,6 +158,20 @@ function fetchData(searchCriteria, resultHolder, callback) {
     });
   }
   if (Object.keys(project).length > 0) { query.project(project); }
+
+  // Sort before skip and limit in order to preserve initial sort integrity
+  if (Object.keys(searchCriteria.sort).length > 0) {
+    query.sort(searchCriteria.sort);
+  }
+  query.skip(searchCriteria.pageStart);
+  if (searchCriteria.pageSize >= 0) query.limit(searchCriteria.pageSize);
+  if (searchCriteria.aggregates.length > 0) {
+    searchCriteria.aggregates.forEach(function(aggregate) {
+      query.unwind(aggregate.unwind).match(aggregate.match)
+        .group(aggregate.group).project(aggregate.project);
+    });
+  }
+
   var self = this;
   query.exec(function(err, records) {
     if (err) return callback(err);


### PR DESCRIPTION
I made this pull request because I ran into an issue on a project I am working at. Even though we have indexes set on MongoDB it makes certain querys excruciatingly slow.  Bug I mention can be read about on this link: [bit.ly/MongoDBSortBug](https://bit.ly/MongoDBSortBug)

TL;DR: MongoDB prioritises indexes which enable it non-blocking sort in aggregation pipelines. Therefore it might choose index that is optimal for sort but not the query itself. It can be "fixed" if you put project between match and sort.